### PR TITLE
Add SonarQube scanning to CI

### DIFF
--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -1,0 +1,41 @@
+name: SonarQube Scan
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  sonarqube:
+    name: SonarQube Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest pytest-cov ruff
+      - name: Lint with ruff
+        run: ruff check --output-format=json --output-file=ruff-report.json .
+        continue-on-error: true
+      - name: Run tests with coverage
+        run: pytest --cov=. --cov-report=xml:coverage.xml || [ $? -eq 5 ]
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v7
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+        with:
+          args: >
+            -Dsonar.projectKey=${{ vars.SONAR_PROJECT_KEY }}
+            -Dsonar.python.coverage.reportPaths=coverage.xml
+            -Dsonar.python.ruff.reportPaths=ruff-report.json
+            -Dsonar.qualitygate.wait=true

--- a/.github/workflows/sonarqube-scan.yml
+++ b/.github/workflows/sonarqube-scan.yml
@@ -20,9 +20,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install dependencies
-        run: |
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest pytest-cov ruff
+        run: pip install pytest pytest-cov ruff
       - name: Lint with ruff
         run: ruff check --output-format=json --output-file=ruff-report.json .
         continue-on-error: true


### PR DESCRIPTION
Wires this repo's CI to the self-hosted SonarQube instance (securecode.purplehax.com), matching the established org-wide pattern.